### PR TITLE
Remove namespace from package name before matching crates

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ _Alias: `-n`_
 
 Followed by *two* arguments: `artifact-kind output-file`
 
-The crate name will be read from the `npm_package_name` environment variable.
+The crate name will be read from the `npm_package_name` environment variable. If the package name includes a namespace (`@namespace/package`), the namespace will be removed when matching the crate name (`package`).
 
 ### Artifact Kind
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cargo-cp-artifact",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Copies compiler artifacts emitted by rustc by parsing Cargo metadata",
   "main": "src/index.js",
   "bin": {

--- a/src/args.js
+++ b/src/args.js
@@ -35,7 +35,15 @@ function getCrateNameFromEnv(env) {
     ].join(" "));
   }
 
-  return env[NPM_ENV];
+  const name = env[NPM_ENV];
+  const firstSlash = name.indexOf("/");
+
+  // This is a namespaced package; assume the crate is the un-namespaced version
+  if (name[0] === "@" && firstSlash > 0) {
+    return name.slice(firstSlash + 1);
+  }
+
+  return name;
 }
 
 function parse(argv, env) {

--- a/test/args.js
+++ b/test/args.js
@@ -84,6 +84,23 @@ describe("Argument Parsing", () => {
     assert.deepStrictEqual(parse(args, env), expected);
   });
 
+  it("should remove namespace from package name", () => {
+    const args = "-nc index.node -- a b c".split(" ");
+    const env = {
+      npm_package_name: "@my-namespace/my-crate"
+    };
+
+    const expected = {
+      artifacts: {
+        "cdylib:my-crate": ["index.node"]
+      },
+      cmd: "a",
+      args: ["b", "c"]
+    };
+
+    assert.deepStrictEqual(parse(args, env), expected);
+  });
+
   it("should be able to provide multiple artifacts", () => {
     const args = `
       -nb my-bin


### PR DESCRIPTION
Resolves https://github.com/neon-bindings/cargo-cp-artifact/issues/5