### PR TITLE
Custom error message when cargo isn't found

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cargo-cp-artifact",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Copies compiler artifacts emitted by rustc by parsing Cargo metadata",
   "main": "src/index.js",
   "bin": {

--- a/src/index.js
+++ b/src/index.js
@@ -18,7 +18,7 @@ function run(argv, env) {
   const rl = readline.createInterface({ input: cp.stdout });
 
   cp.on("error", (err) => {
-    if (options.cmd === 'cargo' && err.code === 'ENOENT') {
+    if (options.cmd === "cargo" && err.code === "ENOENT") {
       console.error(`Error: could not find the \`cargo\` executable.
 
 You can find instructions for installing Rust and Cargo at:

--- a/src/index.js
+++ b/src/index.js
@@ -21,11 +21,11 @@ function run(argv, env) {
     if (options.cmd === 'cargo' && err.code === 'ENOENT') {
       console.error(`Error: could not find the \`cargo\` executable.
 
-If you don't have Rust on your system, you can install it by running:
+You can find instructions for installing Rust and Cargo at:
 
-    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+    https://www.rust-lang.org/tools/install
 
-See https://www.rust-lang.org for more information.`);
+`);
     } else {
       console.error(err);
     }

--- a/src/index.js
+++ b/src/index.js
@@ -18,7 +18,17 @@ function run(argv, env) {
   const rl = readline.createInterface({ input: cp.stdout });
 
   cp.on("error", (err) => {
-    console.error(err);
+    if (options.cmd === 'cargo' && err.code === 'ENOENT') {
+      console.error(`Error: could not find the \`cargo\` executable.
+
+If you don't have Rust on your system, you can install it by running:
+
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+
+See https://www.rust-lang.org for more information.`);
+    } else {
+      console.error(err);
+    }
     process.exitCode = 1;
   });
 


### PR DESCRIPTION
Print a more actionable error message in case the command is `cargo` and it can't be found:

```
Error: could not find the `cargo` executable.

You can find instructions for installing Rust and Cargo at:

    https://www.rust-lang.org/tools/install

```

This seems like a nice thing to do in general for `cargo-cp-artifact`, but also can especially be nicer for the out-of-the-box experience for new Neon users just following instructions and running `npm init neon foo` and getting a build error if they've never installed Rust and don't know how.